### PR TITLE
feat: labels from site-reliability-engineering

### DIFF
--- a/labels.js
+++ b/labels.js
@@ -10,7 +10,25 @@ const colors = {
   githubYellow: 'e4e669',
   githubTeal: 'a2eeef',
   githubGris: 'cfd3d7',
-  githubMagenta: 'd876e3'
+  githubMagenta: 'd876e3',
+  sreYellow: 'fbca04',
+  sreGrey: 'ededed',
+  srePink: '542539',
+  sreLightGrey: 'A9C3DA',
+  sreAqua: '006b75',
+  sreOrange: 'd93f0b',
+  sreGreyish: 'CCEAEF',
+  sreViolet: '2F1B25',
+  srePurple: '0E3EF3',
+  sreBlue: '1d76db',
+  srePurplish: '6D5F9C',
+  sreRed: '9C022F',
+  sreGreellow: 'c2e0c6',
+  sreYellowish: 'fef2c0',
+  sreRedish: 'EF4683',
+  sreOrangish: 'CA8D8D',
+  sreOrangey: 'f9d0c4',
+  sreBlue: '194B9B'
 };
 
 // Create and export the labels
@@ -67,6 +85,132 @@ module.exports = [
     "description": "",
     "color": colors.githubMagenta,
     "name": "Accessiblity | Accessibilité",
+    "alias": []
+  },
+  {
+    "description": "Service provider",
+    "color": colors.sreYellow,
+    "name": "AWS",
+    "alias": []
+  },
+  {
+    "description": "",
+    "color": colors.sreGrey,
+    "name": "Dependencies",
+    "alias": []
+  },
+  {
+    "description": "Documentation",
+    "color": colors.srePink,
+    "name": "Documentation",
+    "alias": []
+  },
+  {
+    "description": "Business Unit",
+    "color": colors.sreLightGrey,
+    "name": "Exposure Notificatios",
+    "alias": []
+  },
+  {
+    "description": "Service provider",
+    "color": colors.sreAqua,
+    "name": "GitHub",
+    "alias": []
+  },
+  {
+    "description": "Issues we are exploring",
+    "color": colors.sreOrange,
+    "name": "Investigation",
+    "alias": []
+  },
+  {
+    "description": "Things that make Internal SRE work",
+    "color": colors.sreGreyish,
+    "name": "Nuts and bolts",
+    "alias": []
+  },
+  {
+    "description": "Activity",
+    "color": colors.sreViolet,
+    "name": "On-call",
+    "alias": []
+  },
+  {
+    "description": "Business Unit",
+    "color": colors.srePurple,
+    "name": "Operations",
+    "alias": []
+  },
+  {
+    "description": "Service provider",
+    "color": colors.sreBlue,
+    "name": "OpsGenie",
+    "alias": []
+  },
+  {
+    "description": "Business Unit",
+    "color": colors.srePurplish,
+    "name": "Partnerships",
+    "alias": []
+  },
+  {
+    "description": "Business Unit",
+    "color": colors.sreRed,
+    "name": "Platform",
+    "alias": []
+  },
+  {
+    "description": "Learnings from post-mortems",
+    "color": colors.sreGreellow,
+    "name": "Post-mortem learning",
+    "alias": []
+  },
+  {
+    "description": "Actual post-mortem",
+    "color": colors.sreYellowish,
+    "name": "Post-mortem",
+    "alias": []
+  },
+  {
+    "description": "Phase",
+    "color": colors.sreRedish,
+    "name": "Production",
+    "alias": []
+  },
+  {
+    "description": "",
+    "color": colors.sreGrey,
+    "name": "Renovate",
+    "alias": []
+  },
+  {
+    "description": "Catch-all for low maintenance SaaS products",
+    "color": colors.sreOrangish,
+    "name": "SaaS",
+    "alias": []
+  },
+  {
+    "description": "Security Hub issue to be triaged",
+    "color": colors.sreOrangey,
+    "name": "Security Hub",
+    "alias": []
+  },
+  {
+    "description": "Issues related to the SRE bot",
+    "color": colors.sreAqua,
+    "name": "SRE Bot",
+    "alias": []
+  },
+  {
+    "description": "",
+    "color": colors.sreGrey,
+    "name": "sync",
+    "alias": []
+  },
+  {
+    "description": "Candidates for automation",
+    "color": colors.sreGrey,
+    "name": "Toil",
     "alias": []
   },
 ];

--- a/labels.js
+++ b/labels.js
@@ -94,6 +94,12 @@ module.exports = [
     "alias": []
   },
   {
+    "description": "Service provider",
+    "color": colors.sreLightGrey,
+    "name": "Azure",
+    "alias": []
+  }
+  {
     "description": "",
     "color": colors.sreGrey,
     "name": "Dependencies",
@@ -103,12 +109,6 @@ module.exports = [
     "description": "Documentation",
     "color": colors.srePink,
     "name": "Documentation",
-    "alias": []
-  },
-  {
-    "description": "Business Unit",
-    "color": colors.sreLightGrey,
-    "name": "Exposure Notificatios",
     "alias": []
   },
   {
@@ -142,12 +142,6 @@ module.exports = [
     "alias": []
   },
   {
-    "description": "Service provider",
-    "color": colors.sreBlue,
-    "name": "OpsGenie",
-    "alias": []
-  },
-  {
     "description": "Business Unit",
     "color": colors.srePurplish,
     "name": "Partnerships",
@@ -169,12 +163,6 @@ module.exports = [
     "description": "Actual post-mortem",
     "color": colors.sreYellowish,
     "name": "Post-mortem",
-    "alias": []
-  },
-  {
-    "description": "Phase",
-    "color": colors.sreRedish,
-    "name": "Production",
     "alias": []
   },
   {


### PR DESCRIPTION
# Summary | Résumé

Add labels from the repo cds-snc/site-reliability-engineering

Some of these labels don't have issues attached to them so we can
probably prune them.

Related to: https://github.com/cds-snc/site-reliability-engineering/issues/767

<img width="372" alt="image" src="https://user-images.githubusercontent.com/87738/214886994-2689fcf9-e30c-4513-8d9f-a15053c33f11.png">

